### PR TITLE
ima-evm-utils: add the runtime dependency for libattr

### DIFF
--- a/recipes-support/ima-evm-utils/ima-evm-utils_1.0.bb
+++ b/recipes-support/ima-evm-utils/ima-evm-utils_1.0.bb
@@ -10,6 +10,7 @@ SRC_URI[md5sum] = "d0e4a4fb92b8fc7c22dfd092c50568ae"
 SRC_URI[sha256sum] = "5701d98069311d0a84ffd67eba047cf46c591f93a55c382a449d10e930b85858"
 
 DEPENDS = "openssl attr keyutils"
+RDEPENDS_${PN} += "libattr"
 
 inherit pkgconfig autotools
 


### PR DESCRIPTION
Signed-off-by: Lans Zhang <jia.zhang@windriver.com>